### PR TITLE
fix: correct nodemailer transporter

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -38,7 +38,7 @@ app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
 // Email transporter configuration
 const createTransporter = () => {
-  return nodemailer.createTransporter({
+  return nodemailer.createTransport({
     service: 'gmail',
     auth: {
       user: process.env.EMAIL_USER,


### PR DESCRIPTION
## Summary
- fix email transporter creation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: TypeError: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_e_689657b416ec83319d40fbe6cec400a4